### PR TITLE
Add basic auth and item management

### DIFF
--- a/my-office-app/src/lib/api.js
+++ b/my-office-app/src/lib/api.js
@@ -1,27 +1,92 @@
 // src/lib/api.js
+import { get } from 'svelte/store';
+import { token } from '$lib/stores';
 
-const BASE_URL = '/api'; // This assumes your backend is proxied locally
+const BASE_URL = '/api';
+
+function authHeaders(extra = {}) {
+	const t = get(token);
+	return t ? { ...extra, Authorization: `Bearer ${t}` } : extra;
+}
 
 export async function fetchOffices() {
-  const res = await fetch(`${BASE_URL}/offices`);
-  if (!res.ok) throw new Error('Failed to fetch offices');
-  return await res.json();
+	const res = await fetch(`${BASE_URL}/offices`, { headers: authHeaders() });
+	if (!res.ok) throw new Error('Failed to fetch offices');
+	return await res.json();
+}
+
+export async function fetchUsers() {
+	const res = await fetch(`${BASE_URL}/users`, { headers: authHeaders() });
+	if (!res.ok) throw new Error('Failed to fetch users');
+	return await res.json();
 }
 
 export async function fetchOfficeUsers(officeId) {
-  const res = await fetch(`${BASE_URL}/offices/${officeId}/users`);
-  if (!res.ok) throw new Error('Failed to fetch users');
-  return await res.json();
+	const res = await fetch(`${BASE_URL}/offices/${officeId}/users`, { headers: authHeaders() });
+	if (!res.ok) throw new Error('Failed to fetch users');
+	return await res.json();
 }
 
 export async function fetchItems(officeId) {
-  const res = await fetch(`${BASE_URL}/offices/${officeId}/items`);
-  if (!res.ok) throw new Error('Failed to fetch items');
-  return await res.json();
+	const res = await fetch(`${BASE_URL}/offices/${officeId}/items`, { headers: authHeaders() });
+	if (!res.ok) throw new Error('Failed to fetch items');
+	return await res.json();
 }
 
 export async function fetchItemDetails(itemId) {
-  const res = await fetch(`${BASE_URL}/items/${itemId}`);
-  if (!res.ok) throw new Error('Failed to fetch item');
-  return await res.json();
+	const res = await fetch(`${BASE_URL}/items/${itemId}`, { headers: authHeaders() });
+	if (!res.ok) throw new Error('Failed to fetch item');
+	return await res.json();
+}
+
+export async function fetchComments(itemId) {
+	const res = await fetch(`${BASE_URL}/items/${itemId}/comments`, { headers: authHeaders() });
+	if (!res.ok) throw new Error('Failed to fetch comments');
+	return await res.json();
+}
+
+export async function fetchCurrentUser() {
+	const res = await fetch(`${BASE_URL}/auth/me`, { headers: authHeaders() });
+	if (!res.ok) throw new Error('Failed to fetch current user');
+	return await res.json();
+}
+
+export async function addItem(item) {
+	const res = await fetch(`${BASE_URL}/items`, {
+		method: 'POST',
+		headers: authHeaders({ 'Content-Type': 'application/json' }),
+		body: JSON.stringify(item)
+	});
+	if (!res.ok) throw new Error('Failed to create item');
+	return await res.json();
+}
+
+export async function updateItem(id, item) {
+	const res = await fetch(`${BASE_URL}/items/${id}`, {
+		method: 'PUT',
+		headers: authHeaders({ 'Content-Type': 'application/json' }),
+		body: JSON.stringify(item)
+	});
+	if (!res.ok) throw new Error('Failed to update item');
+	return await res.json();
+}
+
+export async function addComment(comment) {
+	const res = await fetch(`${BASE_URL}/comments`, {
+		method: 'POST',
+		headers: authHeaders({ 'Content-Type': 'application/json' }),
+		body: JSON.stringify(comment)
+	});
+	if (!res.ok) throw new Error('Failed to create comment');
+	return await res.json();
+}
+
+export async function updateComment(id, comment) {
+	const res = await fetch(`${BASE_URL}/comments/${id}`, {
+		method: 'PUT',
+		headers: authHeaders({ 'Content-Type': 'application/json' }),
+		body: JSON.stringify(comment)
+	});
+	if (!res.ok) throw new Error('Failed to update comment');
+	return await res.json();
 }

--- a/my-office-app/src/lib/stores.js
+++ b/my-office-app/src/lib/stores.js
@@ -1,0 +1,13 @@
+import { writable } from 'svelte/store';
+
+export const token = writable('');
+export const user = writable(null);
+
+if (typeof localStorage !== 'undefined') {
+	const saved = localStorage.getItem('token');
+	if (saved) token.set(saved);
+	token.subscribe((value) => {
+		if (value) localStorage.setItem('token', value);
+		else localStorage.removeItem('token');
+	});
+}

--- a/my-office-app/src/routes/+layout.svelte
+++ b/my-office-app/src/routes/+layout.svelte
@@ -1,7 +1,34 @@
 <script>
 	import '../app.css';
+	import { onMount } from 'svelte';
+	import { token, user } from '$lib/stores';
+	import { fetchCurrentUser } from '$lib/api';
+	import { goto } from '$app/navigation';
 
-	let { children } = $props();
+	onMount(async () => {
+		if ($token && !$user) {
+			try {
+				const data = await fetchCurrentUser();
+				user.set(data);
+			} catch {
+				token.set('');
+			}
+		}
+	});
+
+	const logout = () => {
+		token.set('');
+		user.set(null);
+		goto('/login');
+	};
 </script>
 
-{@render children()}
+<nav class="flex gap-4 bg-gray-100 p-4">
+	{#if $user}
+		<a href="/">Offices</a>
+		<a href="/users">Users</a>
+		<button on:click={logout} class="text-blue-600">Logout</button>
+	{/if}
+</nav>
+
+<slot />

--- a/my-office-app/src/routes/+page.svelte
+++ b/my-office-app/src/routes/+page.svelte
@@ -1,36 +1,45 @@
 <script>
-  import { onMount } from 'svelte';
-  import { fetchOffices } from '$lib/api';
+	import { onMount } from 'svelte';
+	import { fetchOffices } from '$lib/api';
+	import { user } from '$lib/stores';
+	import { goto } from '$app/navigation';
 
-  let offices = [];
-  let error = null;
+	let offices = [];
+	let error = null;
 
-  onMount(async () => {
-    try {
-      const data = await fetchOffices();
-      offices = data.offices;
-    } catch (err) {
-      error = err.message;
-    }
-  });
+	onMount(async () => {
+		if (!$user) {
+			goto('/login');
+			return;
+		}
+		try {
+			const data = await fetchOffices();
+			offices = data.offices;
+			if ($user.role === 'OfficeAdmin') {
+				offices = offices.filter((o) => o.id === $user.officeId);
+			}
+		} catch (err) {
+			error = err.message;
+		}
+	});
 </script>
 
 <main class="p-6">
-  <h1 class="text-2xl font-bold mb-4">Offices</h1>
+	<h1 class="mb-4 text-2xl font-bold">Offices</h1>
 
-  {#if error}
-    <p class="text-red-600">{error}</p>
-  {:else if offices.length === 0}
-    <p>Loading...</p>
-  {:else}
-    <ul class="space-y-4">
-      {#each offices as office}
-        <li class="p-4 bg-white rounded-xl shadow">
-          <h2 class="text-lg font-semibold">{office.name}</h2>
-          <p class="text-sm text-gray-600">{office.address}</p>
-          <p class="text-xs text-gray-400">Max items per user: {office.settings.maxItemsPerUser}</p>
-        </li>
-      {/each}
-    </ul>
-  {/if}
+	{#if error}
+		<p class="text-red-600">{error}</p>
+	{:else if offices.length === 0}
+		<p>Loading...</p>
+	{:else}
+		<ul class="space-y-4">
+			{#each offices as office (office.id)}
+				<li class="rounded-xl bg-white p-4 shadow">
+					<a href={`/offices/${office.id}/items`} class="text-lg font-semibold">{office.name}</a>
+					<p class="text-sm text-gray-600">{office.address}</p>
+					<p class="text-xs text-gray-400">Max items per user: {office.settings.maxItemsPerUser}</p>
+				</li>
+			{/each}
+		</ul>
+	{/if}
 </main>

--- a/my-office-app/src/routes/login/+page.svelte
+++ b/my-office-app/src/routes/login/+page.svelte
@@ -1,0 +1,27 @@
+<script>
+	import { token, user } from '$lib/stores';
+	import { fetchCurrentUser } from '$lib/api';
+	import { goto } from '$app/navigation';
+
+	let inputToken = '';
+	let error = '';
+
+	const login = async () => {
+		token.set(inputToken);
+		try {
+			const data = await fetchCurrentUser();
+			user.set(data);
+			goto('/');
+		} catch {
+			token.set('');
+			error = 'Login failed';
+		}
+	};
+</script>
+
+<main class="mx-auto max-w-md p-6">
+	<h1 class="mb-4 text-2xl font-bold">Login</h1>
+	{#if error}<p class="mb-2 text-red-600">{error}</p>{/if}
+	<input class="mb-4 w-full border p-2" placeholder="Token" bind:value={inputToken} />
+	<button class="bg-blue-600 px-4 py-2 text-white" on:click={login}>Login</button>
+</main>

--- a/my-office-app/src/routes/offices/[id]/items/+page.svelte
+++ b/my-office-app/src/routes/offices/[id]/items/+page.svelte
@@ -1,0 +1,125 @@
+<script>
+	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
+	import { fetchItems, addItem, fetchComments, addComment } from '$lib/api';
+	import { user } from '$lib/stores';
+	import { goto } from '$app/navigation';
+
+	let items = [];
+	let comments = {};
+	let commentInputs = {};
+	let newTitle = '';
+	let newDescription = '';
+	let error = null;
+
+	$: officeId = +$page.params.id;
+
+	const isAdmin = () => {
+		return (
+			$user &&
+			($user.role === 'Admin' || ($user.role === 'OfficeAdmin' && $user.officeId === officeId))
+		);
+	};
+
+	async function loadComments(id) {
+		if (comments[id]) return;
+		try {
+			const data = await fetchComments(id);
+			comments[id] = data.comments;
+		} catch {
+			comments[id] = [];
+		}
+	}
+
+	onMount(async () => {
+		if (!$user) {
+			goto('/login');
+			return;
+		}
+		try {
+			const data = await fetchItems(officeId);
+			items = data.items;
+		} catch (err) {
+			error = err.message;
+		}
+	});
+
+	const createItem = async () => {
+		try {
+			const item = await addItem({
+				title: newTitle,
+				description: newDescription,
+				officeId,
+				createdBy: $user.id
+			});
+			items = [...items, item];
+			newTitle = '';
+			newDescription = '';
+		} catch {
+			alert('Failed to create item');
+		}
+	};
+
+	const createComment = async (id) => {
+		try {
+			const comment = await addComment({
+				itemId: id,
+				userId: $user.id,
+				content: commentInputs[id]
+			});
+			comments[id] = [...(comments[id] || []), comment];
+			commentInputs[id] = '';
+		} catch {
+			alert('Failed to create comment');
+		}
+	};
+</script>
+
+<main class="p-6">
+	<h1 class="mb-4 text-2xl font-bold">Items for Office {officeId}</h1>
+	{#if error}
+		<p class="text-red-600">{error}</p>
+	{:else if items.length === 0}
+		<p>Loading...</p>
+	{:else}
+		<ul class="space-y-4">
+			{#each items as item (item.id)}
+				<li class="rounded border p-4">
+					<div class="font-semibold">{item.title}</div>
+					<div class="mb-2 text-sm text-gray-600">{item.description}</div>
+					<button class="text-sm text-blue-600" on:click={() => loadComments(item.id)}
+						>Load comments</button
+					>
+					{#if comments[item.id]}
+						<ul class="ml-4 mt-2 space-y-1">
+							{#each comments[item.id] as c (c.id)}
+								<li class="text-sm">{c.content}</li>
+							{/each}
+						</ul>
+						{#if isAdmin()}
+							<div class="mt-2 flex gap-2">
+								<input
+									class="flex-1 border p-1"
+									placeholder="Comment"
+									bind:value={commentInputs[item.id]}
+								/>
+								<button class="bg-blue-600 px-2 text-white" on:click={() => createComment(item.id)}
+									>Add</button
+								>
+							</div>
+						{/if}
+					{/if}
+				</li>
+			{/each}
+		</ul>
+	{/if}
+
+	{#if isAdmin()}
+		<div class="mt-6">
+			<h2 class="mb-2 font-semibold">Add Item</h2>
+			<input class="mr-2 border p-1" placeholder="Title" bind:value={newTitle} />
+			<input class="mr-2 border p-1" placeholder="Description" bind:value={newDescription} />
+			<button class="bg-blue-600 px-2 py-1 text-white" on:click={createItem}>Add</button>
+		</div>
+	{/if}
+</main>

--- a/my-office-app/src/routes/users/+page.svelte
+++ b/my-office-app/src/routes/users/+page.svelte
@@ -1,0 +1,41 @@
+<script>
+	import { onMount } from 'svelte';
+	import { fetchUsers } from '$lib/api';
+	import { user } from '$lib/stores';
+	import { goto } from '$app/navigation';
+
+	let users = [];
+	let error = null;
+
+	onMount(async () => {
+		if (!$user) {
+			goto('/login');
+			return;
+		}
+		try {
+			const data = await fetchUsers();
+			users = data.users;
+			if ($user.role === 'OfficeAdmin') {
+				users = users.filter((u) => u.officeId === $user.officeId);
+			}
+		} catch (err) {
+			error = err.message;
+		}
+	});
+</script>
+
+<main class="p-6">
+	<h1 class="mb-4 text-2xl font-bold">Users</h1>
+
+	{#if error}
+		<p class="text-red-600">{error}</p>
+	{:else if users.length === 0}
+		<p>Loading...</p>
+	{:else}
+		<ul class="space-y-2">
+			{#each users as u (u.id)}
+				<li class="rounded border p-2">{u.username} - {u.role} (Office {u.officeId})</li>
+			{/each}
+		</ul>
+	{/if}
+</main>

--- a/my-office-app/tailwind.config.ts
+++ b/my-office-app/tailwind.config.ts
@@ -1,11 +1,10 @@
 import type { Config } from 'tailwindcss';
+import typography from '@tailwindcss/typography';
 
 export default {
 	content: ['./src/**/*.{html,js,svelte,ts}'],
-
 	theme: {
 		extend: {}
 	},
-
-	plugins: [require('@tailwindcss/typography')]
+	plugins: [typography]
 } as Config;


### PR DESCRIPTION
## Summary
- implement persistent auth store
- enhance API helper with Authorization headers
- update layout with login/logout logic
- filter offices and users by role
- add login and admin-only item management screens
- fix tailwind config

## Testing
- `npm run lint`
- `npm test` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_b_685dfee76b20832e9a424a8cf7285edc