### PR TITLE
feat(flutter): add office and item detail navigation

### DIFF
--- a/flutter_app/lib/api.dart
+++ b/flutter_app/lib/api.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
-
 final String baseUrl = dotenv.env['BASE_URL'] ?? 'http://localhost:8080/api';
 
 Future<List<dynamic>> fetchOffices() async {
@@ -14,4 +13,57 @@ Future<List<dynamic>> fetchOffices() async {
 
   final body = json.decode(res.body);
   return body['offices'];
+}
+
+Future<Map<String, dynamic>> fetchOfficeDetails(int officeId) async {
+  final res = await http.get(Uri.parse('$baseUrl/offices/$officeId'));
+
+  if (res.statusCode != 200) {
+    throw Exception('Failed to load office details');
+  }
+
+  return json.decode(res.body);
+}
+
+Future<List<dynamic>> fetchOfficeItems(int officeId) async {
+  final res = await http.get(Uri.parse('$baseUrl/offices/$officeId/items'));
+
+  if (res.statusCode != 200) {
+    throw Exception('Failed to load office items');
+  }
+
+  final body = json.decode(res.body);
+  return body['items'];
+}
+
+Future<List<dynamic>> fetchItemComments(int itemId) async {
+  final res = await http.get(Uri.parse('$baseUrl/items/$itemId/comments'));
+
+  if (res.statusCode != 200) {
+    throw Exception('Failed to load item comments');
+  }
+
+  final body = json.decode(res.body);
+  return body['comments'];
+}
+
+Future<Map<String, dynamic>> fetchItemDetails(int itemId) async {
+  final res = await http.get(Uri.parse('$baseUrl/items/$itemId'));
+
+  if (res.statusCode != 200) {
+    throw Exception('Failed to load item details');
+  }
+
+  return json.decode(res.body);
+}
+
+Future<List<dynamic>> fetchUsers() async {
+  final res = await http.get(Uri.parse('$baseUrl/users'));
+
+  if (res.statusCode != 200) {
+    throw Exception('Failed to load users');
+  }
+
+  final body = json.decode(res.body);
+  return body['users'];
 }

--- a/flutter_app/lib/item_detail_page.dart
+++ b/flutter_app/lib/item_detail_page.dart
@@ -1,0 +1,356 @@
+import 'package:flutter/material.dart';
+import 'api.dart';
+
+class ItemDetailPage extends StatefulWidget {
+  final int itemId;
+  final String itemTitle;
+
+  const ItemDetailPage({
+    super.key,
+    required this.itemId,
+    required this.itemTitle,
+  });
+
+  @override
+  State<ItemDetailPage> createState() => _ItemDetailPageState();
+}
+
+class _ItemDetailPageState extends State<ItemDetailPage> {
+  late Future<Map<String, dynamic>> itemDetailsFuture;
+  late Future<List<dynamic>> commentsFuture;
+  late Future<List<dynamic>> usersFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    itemDetailsFuture = fetchItemDetails(widget.itemId);
+    commentsFuture = fetchItemComments(widget.itemId);
+    usersFuture = fetchUsers();
+  }
+
+  String _getUserInitials(Map<String, dynamic> user) {
+    final firstName = user['firstName'] ?? '';
+    final lastName = user['lastName'] ?? '';
+    final firstInitial = firstName.isNotEmpty ? firstName[0].toUpperCase() : '';
+    final lastInitial = lastName.isNotEmpty ? lastName[0].toUpperCase() : '';
+    return '$firstInitial$lastInitial';
+  }
+
+  String _getUserName(Map<String, dynamic> user) {
+    final firstName = user['firstName'] ?? '';
+    final lastName = user['lastName'] ?? '';
+    return '$firstName $lastName'.trim();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.itemTitle)),
+      body: Column(
+        children: [
+          FutureBuilder<List<dynamic>>(
+            future: Future.wait([itemDetailsFuture, usersFuture]),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return Container(
+                  width: double.infinity,
+                  margin: const EdgeInsets.all(16.0),
+                  padding: const EdgeInsets.all(16.0),
+                  decoration: BoxDecoration(
+                    color: Colors.green.shade50,
+                    borderRadius: BorderRadius.circular(8.0),
+                  ),
+                  child: const Center(child: CircularProgressIndicator()),
+                );
+              } else if (snapshot.hasError) {
+                return Container(
+                  width: double.infinity,
+                  margin: const EdgeInsets.all(16.0),
+                  padding: const EdgeInsets.all(16.0),
+                  decoration: BoxDecoration(
+                    color: Colors.red.shade50,
+                    borderRadius: BorderRadius.circular(8.0),
+                  ),
+                  child: Text('Error loading item: ${snapshot.error}'),
+                );
+              } else {
+                final item = snapshot.data![0];
+                final users = snapshot.data![1];
+
+                final userMap = <int, Map<String, dynamic>>{};
+                for (final user in users) {
+                  userMap[user['id']] = user;
+                }
+
+                final creator = userMap[item['createdBy']];
+                final creatorName = creator != null
+                    ? _getUserName(creator)
+                    : 'Unknown User';
+
+                return Container(
+                  width: double.infinity,
+                  margin: const EdgeInsets.all(16.0),
+                  padding: const EdgeInsets.all(16.0),
+                  decoration: BoxDecoration(
+                    color: Colors.green.shade50,
+                    borderRadius: BorderRadius.circular(8.0),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        item['title'],
+                        style: const TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        item['description'],
+                        style: const TextStyle(fontSize: 16),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Created by $creatorName',
+                        style: const TextStyle(
+                          fontSize: 14,
+                          color: Colors.grey,
+                        ),
+                      ),
+                      Text(
+                        'Created: ${_formatDate(item['createdAt'])}',
+                        style: const TextStyle(
+                          fontSize: 14,
+                          color: Colors.grey,
+                        ),
+                      ),
+                      if (item['updatedAt'] != null)
+                        Text(
+                          'Updated: ${_formatDate(item['updatedAt'])}',
+                          style: const TextStyle(
+                            fontSize: 14,
+                            color: Colors.grey,
+                          ),
+                        ),
+                    ],
+                  ),
+                );
+              }
+            },
+          ),
+          // Comments Section
+          Expanded(
+            child: FutureBuilder<List<List<dynamic>>>(
+              future: Future.wait([commentsFuture, usersFuture]),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return Column(
+                    children: [
+                      const Padding(
+                        padding: EdgeInsets.symmetric(horizontal: 16.0),
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            'Comments',
+                            style: TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                      ),
+                      const Expanded(
+                        child: Center(child: CircularProgressIndicator()),
+                      ),
+                    ],
+                  );
+                } else if (snapshot.hasError) {
+                  return Column(
+                    children: [
+                      const Padding(
+                        padding: EdgeInsets.symmetric(horizontal: 16.0),
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            'Comments',
+                            style: TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                      ),
+                      Expanded(
+                        child: Center(
+                          child: Text(
+                            'Error loading comments: ${snapshot.error}',
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                } else {
+                  final comments = snapshot.data![0];
+                  final users = snapshot.data![1];
+
+                  final userMap = <int, Map<String, dynamic>>{};
+                  for (final user in users) {
+                    userMap[user['id']] = user;
+                  }
+
+                  return Column(
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            'Comments (${comments.length})',
+                            style: const TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                      ),
+                      Expanded(
+                        child: comments.isEmpty
+                            ? const Center(
+                                child: Text('No comments found for this item.'),
+                              )
+                            : Builder(
+                                builder: (context) {
+                                  final sortedComments = List<dynamic>.from(
+                                    comments,
+                                  );
+                                  sortedComments.sort((a, b) {
+                                    try {
+                                      final dateA = DateTime.parse(
+                                        a['createdAt'],
+                                      );
+                                      final dateB = DateTime.parse(
+                                        b['createdAt'],
+                                      );
+                                      return dateB.compareTo(dateA);
+                                    } catch (e) {
+                                      return 0;
+                                    }
+                                  });
+
+                                  return ListView.builder(
+                                    padding: const EdgeInsets.all(16.0),
+                                    itemCount: sortedComments.length,
+                                    itemBuilder: (context, index) {
+                                      final comment = sortedComments[index];
+                                      final user = userMap[comment['userId']];
+                                      final userInitials = user != null
+                                          ? _getUserInitials(user)
+                                          : 'U';
+                                      final userName = user != null
+                                          ? _getUserName(user)
+                                          : 'Unknown User';
+
+                                      return Card(
+                                        elevation: 0.0,
+                                        margin: const EdgeInsets.only(
+                                          bottom: 8.0,
+                                        ),
+                                        child: Padding(
+                                          padding: const EdgeInsets.all(12.0),
+                                          child: Column(
+                                            crossAxisAlignment:
+                                                CrossAxisAlignment.start,
+                                            children: [
+                                              Row(
+                                                children: [
+                                                  CircleAvatar(
+                                                    radius: 16,
+                                                    backgroundColor:
+                                                        Colors.blue.shade100,
+                                                    child: Text(
+                                                      userInitials,
+                                                      style: const TextStyle(
+                                                        fontSize: 12,
+                                                        fontWeight:
+                                                            FontWeight.bold,
+                                                      ),
+                                                    ),
+                                                  ),
+                                                  const SizedBox(width: 8),
+                                                  Text(
+                                                    userName,
+                                                    style: const TextStyle(
+                                                      fontWeight:
+                                                          FontWeight.bold,
+                                                    ),
+                                                  ),
+                                                  const Spacer(),
+                                                  Text(
+                                                    _formatDate(
+                                                      comment['createdAt'],
+                                                    ),
+                                                    style: const TextStyle(
+                                                      fontSize: 12,
+                                                      color: Colors.grey,
+                                                    ),
+                                                  ),
+                                                ],
+                                              ),
+                                              const SizedBox(height: 8),
+                                              Text(comment['content']),
+                                            ],
+                                          ),
+                                        ),
+                                      );
+                                    },
+                                  );
+                                },
+                              ),
+                      ),
+                    ],
+                  );
+                }
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatDate(String dateString) {
+    try {
+      final date = DateTime.parse(dateString);
+
+      const months = [
+        'Jan',
+        'Feb',
+        'Mar',
+        'Apr',
+        'May',
+        'Jun',
+        'Jul',
+        'Aug',
+        'Sep',
+        'Oct',
+        'Nov',
+        'Dec',
+      ];
+
+      final month = months[date.month - 1];
+      final day = date.day;
+      final year = date.year;
+
+      final hour = date.hour == 0
+          ? 12
+          : (date.hour > 12 ? date.hour - 12 : date.hour);
+      final minute = date.minute.toString().padLeft(2, '0');
+      final period = date.hour >= 12 ? 'PM' : 'AM';
+
+      return '$day $month $year $hour:$minute$period';
+    } catch (e) {
+      return dateString;
+    }
+  }
+}

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -1,18 +1,16 @@
-import 'dart:io';
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'env_selector.dart';
 import 'api.dart';
+import 'office_detail_page.dart';
 
 Future<void> main() async {
-
   try {
     await dotenv.load(fileName: getEnvFile());
   } catch (e) {
-    print("Warning: Failed to load .env file: $e");
+    debugPrint("Warning: Failed to load .env file: $e");
   }
-  
+
   runApp(const RebotApp());
 }
 
@@ -69,6 +67,17 @@ class _OfficeListPageState extends State<OfficeListPage> {
                     '${office['settings']['maxItemsPerUser']} items',
                     style: const TextStyle(fontSize: 12),
                   ),
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => OfficeDetailPage(
+                          officeId: office['id'],
+                          officeName: office['name'],
+                        ),
+                      ),
+                    );
+                  },
                 );
               },
             );

--- a/flutter_app/lib/office_detail_page.dart
+++ b/flutter_app/lib/office_detail_page.dart
@@ -1,0 +1,245 @@
+import 'package:flutter/material.dart';
+import 'api.dart';
+import 'item_detail_page.dart';
+
+class OfficeDetailPage extends StatefulWidget {
+  final int officeId;
+  final String officeName;
+
+  const OfficeDetailPage({
+    super.key,
+    required this.officeId,
+    required this.officeName,
+  });
+
+  @override
+  State<OfficeDetailPage> createState() => _OfficeDetailPageState();
+}
+
+class _OfficeDetailPageState extends State<OfficeDetailPage> {
+  late Future<Map<String, dynamic>> officeDetailsFuture;
+  late Future<List<dynamic>> itemsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    officeDetailsFuture = _getOfficeFromList();
+    itemsFuture = fetchOfficeItems(widget.officeId);
+  }
+
+  Future<Map<String, dynamic>> _getOfficeFromList() async {
+    final offices = await fetchOffices();
+    final office = offices.firstWhere(
+      (office) => office['id'] == widget.officeId,
+      orElse: () => throw Exception('Office not found'),
+    );
+    return office;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.officeName)),
+      body: Column(
+        children: [
+          // Office Details Section
+          FutureBuilder<Map<String, dynamic>>(
+            future: officeDetailsFuture,
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Padding(
+                  padding: EdgeInsets.all(16.0),
+                  child: Center(child: CircularProgressIndicator()),
+                );
+              } else if (snapshot.hasError) {
+                return Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Text(
+                    'Error loading office details: ${snapshot.error}',
+                  ),
+                );
+              } else {
+                final office = snapshot.data!;
+                return Container(
+                  width: double.infinity,
+                  margin: const EdgeInsets.all(16.0),
+                  padding: const EdgeInsets.all(16.0),
+                  decoration: BoxDecoration(
+                    color: Colors.blue.shade50,
+                    borderRadius: BorderRadius.circular(8.0),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        office['name'],
+                        style: const TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        office['address'],
+                        style: const TextStyle(fontSize: 16),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Max items per user: ${office['settings']['maxItemsPerUser']}',
+                        style: const TextStyle(
+                          fontSize: 14,
+                          color: Colors.grey,
+                        ),
+                      ),
+                      Text(
+                        'Timezone: ${office['settings']['timezone']}',
+                        style: const TextStyle(
+                          fontSize: 14,
+                          color: Colors.grey,
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              }
+            },
+          ),
+          // Items Section
+          Expanded(
+            child: FutureBuilder<List<dynamic>>(
+              future: itemsFuture,
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return Column(
+                    children: [
+                      const Padding(
+                        padding: EdgeInsets.symmetric(horizontal: 16.0),
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            'Items',
+                            style: TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                      ),
+                      const Expanded(
+                        child: Center(child: CircularProgressIndicator()),
+                      ),
+                    ],
+                  );
+                } else if (snapshot.hasError) {
+                  return Column(
+                    children: [
+                      const Padding(
+                        padding: EdgeInsets.symmetric(horizontal: 16.0),
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            'Items',
+                            style: TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                      ),
+                      Expanded(
+                        child: Center(
+                          child: Text('Error loading items: ${snapshot.error}'),
+                        ),
+                      ),
+                    ],
+                  );
+                } else {
+                  final items = snapshot.data!;
+
+                  return Column(
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            'Items (${items.length})',
+                            style: const TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                      ),
+                      Expanded(
+                        child: items.isEmpty
+                            ? const Center(
+                                child: Text('No items found for this office.'),
+                              )
+                            : Builder(
+                                builder: (context) {
+                                  final sortedItems = List<dynamic>.from(items);
+                                  sortedItems.sort((a, b) {
+                                    try {
+                                      final dateA = DateTime.parse(
+                                        a['createdAt'],
+                                      );
+                                      final dateB = DateTime.parse(
+                                        b['createdAt'],
+                                      );
+                                      return dateB.compareTo(dateA);
+                                    } catch (e) {
+                                      return 0;
+                                    }
+                                  });
+
+                                  return ListView.builder(
+                                    padding: const EdgeInsets.all(16.0),
+                                    itemCount: sortedItems.length,
+                                    itemBuilder: (context, index) {
+                                      final item = sortedItems[index];
+                                      return Card(
+                                        elevation: 0.0,
+                                        margin: const EdgeInsets.only(
+                                          bottom: 8.0,
+                                        ),
+                                        child: ListTile(
+                                          title: Text(item['title']),
+                                          subtitle: Text(
+                                            item['description'],
+                                            maxLines: 2,
+                                            overflow: TextOverflow.ellipsis,
+                                          ),
+                                          trailing: const Icon(
+                                            Icons.arrow_forward_ios,
+                                          ),
+                                          onTap: () {
+                                            Navigator.push(
+                                              context,
+                                              MaterialPageRoute(
+                                                builder: (context) =>
+                                                    ItemDetailPage(
+                                                      itemId: item['id'],
+                                                      itemTitle: item['title'],
+                                                    ),
+                                              ),
+                                            );
+                                          },
+                                        ),
+                                      );
+                                    },
+                                  );
+                                },
+                              ),
+                      ),
+                    ],
+                  );
+                }
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_app/test/widget_test.dart
+++ b/flutter_app/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:rebot_flutter_app/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const RebotApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
- Add office detail page with navigation from office list
- Add item detail page with comments and user information
- Enhance API service with office items, item details, and comments endpoints
- Implement user initials and name display in item comments
- Add date formatting utilities for created/updated timestamps
- Update main app to include navigation to office detail pages
- Fix widget test to use correct app component name